### PR TITLE
Feat/auth use case

### DIFF
--- a/__tests__/unit/data/usecases/auth/db-auth.spec.ts
+++ b/__tests__/unit/data/usecases/auth/db-auth.spec.ts
@@ -45,7 +45,7 @@ describe('# Usecase - Auth', () => {
     jest.spyOn(repository, 'findUserByEmail').mockResolvedValueOnce(null);
 
     await expect(useCase.execute(params)).rejects.toEqual(
-      new BusinessError('User not found', 404)
+      new BusinessError('Invalid credentials', 404)
     );
   });
 
@@ -66,7 +66,7 @@ describe('# Usecase - Auth', () => {
       .mockResolvedValueOnce(false);
 
     await expect(useCase.execute(params)).rejects.toEqual(
-      new BusinessError('Invalid password', 401)
+      new BusinessError('Invalid credentials', 401)
     );
 
     expect(compareSpy).toHaveBeenCalledWith(params.password, 'hashedpassword');

--- a/src/data/usecases/auth/db-auth.ts
+++ b/src/data/usecases/auth/db-auth.ts
@@ -19,7 +19,7 @@ export class DbAuthUseCase implements IAuthUseCase {
     const user = await this.userRepository.findUserByEmail(options.email);
 
     if (!user) {
-      throw new BusinessError('User not found', 401);
+      throw new BusinessError('Invalid credentials', 401);
     }
 
     const isValidPassword = await this.hashService.compareHash(
@@ -28,7 +28,7 @@ export class DbAuthUseCase implements IAuthUseCase {
     );
 
     if (!isValidPassword) {
-      throw new BusinessError('Invalid password', 401);
+      throw new BusinessError('Invalid credentials', 401);
     }
 
     const token = await this.jwtService.sign(user.id);

--- a/src/infra/http/express/middlewares/rate-limit.ts
+++ b/src/infra/http/express/middlewares/rate-limit.ts
@@ -2,7 +2,7 @@ import rateLimit from 'express-rate-limit';
 
 // One minute => 100 requests
 export const rateLimitRequests = rateLimit({
-  windowMs: 60000, // 1 hour
+  windowMs: 60000, // 1 min
   max: 100, // limit each IP to 100 requests per windowMs
   handler: (_, res) => {
     res.status(429).json({

--- a/src/infra/http/express/routes/auth.ts
+++ b/src/infra/http/express/routes/auth.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import { expressAdapterRoute } from '../../../../main/adapters/express-route-adapter';
+import { makeAuthControllerFactory } from '../../../../main/factories/controllers/auth/auth';
+
+export default (router: Router): void => {
+  router.post('/auth', expressAdapterRoute(makeAuthControllerFactory()));
+};

--- a/src/infra/validators/auth/auth.ts
+++ b/src/infra/validators/auth/auth.ts
@@ -1,0 +1,14 @@
+import * as yup from 'yup';
+import { IValidator } from '../../../presentation/protocols/validator';
+import { validator } from '../validator';
+
+export class AuthValidator implements IValidator {
+  validate(input: any): string | {} | Promise<string | {}> {
+    const schema = yup.object().shape({
+      email: yup.string().email().required(),
+      password: yup.string().required(),
+    });
+
+    return validator(schema, input);
+  }
+}

--- a/src/main/factories/controllers/auth/auth.ts
+++ b/src/main/factories/controllers/auth/auth.ts
@@ -1,0 +1,7 @@
+import { AuthValidator } from '../../../../infra/validators/auth/auth';
+import { AuthController } from '../../../../presentation/controllers/auth/auth';
+import { Controller } from '../../../../presentation/protocols/controller';
+import { makeAuthUseCaseFactory } from '../../usecases/auth/auth';
+
+export const makeAuthControllerFactory = (): Controller =>
+  new AuthController(makeAuthUseCaseFactory(), new AuthValidator());

--- a/src/main/factories/usecases/auth/auth.ts
+++ b/src/main/factories/usecases/auth/auth.ts
@@ -1,0 +1,13 @@
+import { DbAuthUseCase } from '../../../../data/usecases/auth/db-auth';
+import { IAuthUseCase } from '../../../../domain/usecases/auth/auth';
+import { JwtAdapter } from '../../../../infra/auth-token/jwt-adaptert';
+import { prismaClient } from '../../../../infra/db/prisma/client';
+import { UserPrismaRepository } from '../../../../infra/db/prisma/repositories/user-prisma-repository';
+import { BcryptHashAdapter } from '../../../../infra/hash/bcrypt-adapter';
+
+export const makeAuthUseCaseFactory = (): IAuthUseCase => {
+  const repository = new UserPrismaRepository(prismaClient);
+  const hash = new BcryptHashAdapter();
+  const jwt = new JwtAdapter();
+  return new DbAuthUseCase(repository, hash, jwt);
+};


### PR DESCRIPTION
- Feat: Add factories and create route to make auth
- Feat: Add validator to auth controller
- Refactor: ajust comment in middleware rate limit
- Refactor: ajust message to return 'invalid credentials' instead of 'invalid password or email'